### PR TITLE
Fix profile navigation bug

### DIFF
--- a/app/src/main/java/com/example/blooddonation/feature/dashboard/Dashboard.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/dashboard/Dashboard.kt
@@ -350,7 +350,7 @@ fun DashboardScreen(navController: NavController, uid: String) {
                                             backgroundColor = redColor,
                                             iconColor = whiteColor
                                         ) {
-                                            navController.navigate("my_profile/{uid}")
+                                            navController.navigate("my_profile/$uid")
                                         }
                                     }
                                     item {


### PR DESCRIPTION
## Summary
- fix navigation to the profile screen by interpolating the user ID

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441165f4188325ba49b6604f5b4fe2