### PR TITLE
Remove custom color constants

### DIFF
--- a/app/src/main/java/com/example/blooddonation/feature/admin/AdminDashboardScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/admin/AdminDashboardScreen.kt
@@ -82,9 +82,7 @@ import java.util.Calendar
 import java.util.Locale
 
 
-private val RedColor @Composable get() = MaterialTheme.colorScheme.primary
-private val BlackColor @Composable get() = MaterialTheme.colorScheme.onBackground
-private val WhiteColor @Composable get() = MaterialTheme.colorScheme.onPrimary
+// Removed color aliases; use theme colors directly
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -223,8 +221,8 @@ fun AdminDashboardScreen(
     if (showLogoutDialog) {
         AlertDialog(
             onDismissRequest = { showLogoutDialog = false },
-            title = { Text("Confirm Logout", color = RedColor, fontWeight = FontWeight.Bold) },
-            text = { Text("Are you sure you want to logout?", color = BlackColor) },
+            title = { Text("Confirm Logout", color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold) },
+            text = { Text("Are you sure you want to logout?", color = MaterialTheme.colorScheme.onBackground) },
             confirmButton = {
                 Button(
                     onClick = {
@@ -234,17 +232,17 @@ fun AdminDashboardScreen(
                         }
                         showLogoutDialog = false
                     },
-                    colors = ButtonDefaults.buttonColors(containerColor = RedColor)
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
                 ) {
-                    Text("Logout", color = WhiteColor)
+                    Text("Logout", color = MaterialTheme.colorScheme.onPrimary)
                 }
             },
             dismissButton = {
                 Button(
                     onClick = { showLogoutDialog = false },
-                    colors = ButtonDefaults.buttonColors(containerColor = BlackColor)
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.onBackground)
                 ) {
-                    Text("Cancel", color = WhiteColor)
+                    Text("Cancel", color = MaterialTheme.colorScheme.onPrimary)
                 }
             }
         )
@@ -262,7 +260,7 @@ fun CampItem(
         modifier = Modifier
             .fillMaxWidth()
             .padding(8.dp),
-        colors = CardDefaults.cardColors(containerColor = WhiteColor),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.onPrimary),
         elevation = CardDefaults.cardElevation()
     ) {
         Column(
@@ -290,7 +288,7 @@ fun CampItem(
                     Icon(
                         imageVector = Icons.Default.AccountCircle,
                         contentDescription = null,
-                        tint = RedColor,
+                        tint = MaterialTheme.colorScheme.primary,
                         modifier = Modifier
                             .size(72.dp)
                             .clip(CircleShape)
@@ -304,27 +302,27 @@ fun CampItem(
                     Text(
                         text = camp.name,
                         style = MaterialTheme.typography.titleLarge,
-                        color = RedColor
+                        color = MaterialTheme.colorScheme.primary
                     )
-                    Text(text = "Location: ${camp.location}", color = BlackColor)
-                    Text(text = "Date: ${camp.date}", color = BlackColor)
-                    Text(text = camp.description, color = BlackColor, maxLines = 2)
+                    Text(text = "Location: ${camp.location}", color = MaterialTheme.colorScheme.onBackground)
+                    Text(text = "Date: ${camp.date}", color = MaterialTheme.colorScheme.onBackground)
+                    Text(text = camp.description, color = MaterialTheme.colorScheme.onBackground, maxLines = 2)
                 }
             }
             Spacer(modifier = Modifier.height(8.dp))
             Row {
                 Button(
                     onClick = { onEdit(camp) },
-                    colors = ButtonDefaults.buttonColors(containerColor = RedColor)
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
                 ) {
-                    Text("Edit", color = WhiteColor)
+                    Text("Edit", color = MaterialTheme.colorScheme.onPrimary)
                 }
                 Spacer(modifier = Modifier.width(8.dp))
                 Button(
                     onClick = { onDelete(camp) },
-                    colors = ButtonDefaults.buttonColors(containerColor = BlackColor)
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.onBackground)
                 ) {
-                    Text("Delete", color = WhiteColor)
+                    Text("Delete", color = MaterialTheme.colorScheme.onPrimary)
                 }
             }
         }
@@ -404,11 +402,11 @@ fun CampDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        containerColor = WhiteColor,
+        containerColor = MaterialTheme.colorScheme.onPrimary,
         title = {
             Text(
                 text = if (initialCamp == null) "Add Camp" else "Edit Camp",
-                color = RedColor
+                color = MaterialTheme.colorScheme.primary
             )
         },
         text = {
@@ -423,16 +421,16 @@ fun CampDialog(
                     label = { Text("Camp Name") },
                     isError = showValidationError && !isNameValid,
                     colors = TextFieldDefaults.colors(
-                        focusedContainerColor = WhiteColor,
-                        unfocusedContainerColor = WhiteColor,
-                        focusedIndicatorColor = RedColor,
-                        unfocusedIndicatorColor = RedColor,
-                        focusedLabelColor = RedColor,
-                        unfocusedLabelColor = BlackColor,
-                        cursorColor = RedColor,
+                        focusedContainerColor = MaterialTheme.colorScheme.onPrimary,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.onPrimary,
+                        focusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                        unfocusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                        focusedLabelColor = MaterialTheme.colorScheme.primary,
+                        unfocusedLabelColor = MaterialTheme.colorScheme.onBackground,
+                        cursorColor = MaterialTheme.colorScheme.primary,
                         errorIndicatorColor = Color.Red
                     ),
-                    textStyle = TextStyle(color = BlackColor),
+                    textStyle = TextStyle(color = MaterialTheme.colorScheme.onBackground),
                     singleLine = true
                 )
                 if (showValidationError && !isNameValid) {
@@ -456,16 +454,16 @@ fun CampDialog(
                         label = { Text("Location") },
                         isError = showValidationError && !isLocationValid,
                         colors = TextFieldDefaults.colors(
-                            focusedContainerColor = WhiteColor,
-                            unfocusedContainerColor = WhiteColor,
-                            focusedIndicatorColor = RedColor,
-                            unfocusedIndicatorColor = RedColor,
-                            focusedLabelColor = RedColor,
-                            unfocusedLabelColor = BlackColor,
-                            cursorColor = RedColor,
+                            focusedContainerColor = MaterialTheme.colorScheme.onPrimary,
+                            unfocusedContainerColor = MaterialTheme.colorScheme.onPrimary,
+                            focusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                            unfocusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                            focusedLabelColor = MaterialTheme.colorScheme.primary,
+                            unfocusedLabelColor = MaterialTheme.colorScheme.onBackground,
+                            cursorColor = MaterialTheme.colorScheme.primary,
                             errorIndicatorColor = Color.Red
                         ),
-                        textStyle = TextStyle(color = BlackColor),
+                        textStyle = TextStyle(color = MaterialTheme.colorScheme.onBackground),
                         singleLine = true,
                         modifier = Modifier
                             .fillMaxWidth()
@@ -512,7 +510,7 @@ fun CampDialog(
                         Icon(
                             painter = painterResource(id = R.drawable.ic_calendar), // Use your calendar icon here
                             contentDescription = "Pick Date",
-                            tint = RedColor,
+                            tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.clickable { showDatePicker = true }
                         )
                     },
@@ -520,16 +518,16 @@ fun CampDialog(
                     enabled = true,
                     isError = showValidationError && !isDateValid,
                     colors = TextFieldDefaults.colors(
-                        focusedContainerColor = WhiteColor,
-                        unfocusedContainerColor = WhiteColor,
-                        focusedIndicatorColor = RedColor,
-                        unfocusedIndicatorColor = RedColor,
-                        focusedLabelColor = RedColor,
-                        unfocusedLabelColor = BlackColor,
-                        cursorColor = RedColor,
+                        focusedContainerColor = MaterialTheme.colorScheme.onPrimary,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.onPrimary,
+                        focusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                        unfocusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                        focusedLabelColor = MaterialTheme.colorScheme.primary,
+                        unfocusedLabelColor = MaterialTheme.colorScheme.onBackground,
+                        cursorColor = MaterialTheme.colorScheme.primary,
                         errorIndicatorColor = Color.Red
                     ),
-                    textStyle = TextStyle(color = BlackColor),
+                    textStyle = TextStyle(color = MaterialTheme.colorScheme.onBackground),
                     modifier = Modifier
                         .fillMaxWidth()
                         .clickable { showDatePicker = true }
@@ -549,24 +547,24 @@ fun CampDialog(
                     onValueChange = { description = it },
                     label = { Text("Description") },
                     colors = TextFieldDefaults.colors(
-                        focusedContainerColor = WhiteColor,
-                        unfocusedContainerColor = WhiteColor,
-                        focusedIndicatorColor = RedColor,
-                        unfocusedIndicatorColor = RedColor,
-                        focusedLabelColor = RedColor,
-                        unfocusedLabelColor = BlackColor,
-                        cursorColor = RedColor
+                        focusedContainerColor = MaterialTheme.colorScheme.onPrimary,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.onPrimary,
+                        focusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                        unfocusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                        focusedLabelColor = MaterialTheme.colorScheme.primary,
+                        unfocusedLabelColor = MaterialTheme.colorScheme.onBackground,
+                        cursorColor = MaterialTheme.colorScheme.primary
                     ),
-                    textStyle = TextStyle(color = BlackColor)
+                    textStyle = TextStyle(color = MaterialTheme.colorScheme.onBackground)
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
 
                 Button(
                     onClick = { launcher.launch("image/*") },
-                    colors = ButtonDefaults.buttonColors(containerColor = RedColor)
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
                 ) {
-                    Text("Choose Image", color = WhiteColor)
+                    Text("Choose Image", color = MaterialTheme.colorScheme.onPrimary)
                 }
 
                 if (savedImagePath.isNotEmpty()) {
@@ -600,17 +598,17 @@ fun CampDialog(
                     }
                 },
                 enabled = isFormValid,
-                colors = ButtonDefaults.buttonColors(containerColor = RedColor)
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
             ) {
-                Text("Save", color = WhiteColor)
+                Text("Save", color = MaterialTheme.colorScheme.onPrimary)
             }
         },
         dismissButton = {
             Button(
                 onClick = onDismiss,
-                colors = ButtonDefaults.buttonColors(containerColor = BlackColor)
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.onBackground)
             ) {
-                Text("Cancel", color = WhiteColor)
+                Text("Cancel", color = MaterialTheme.colorScheme.onPrimary)
             }
         }
     )

--- a/app/src/main/java/com/example/blooddonation/feature/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/dashboard/DashboardScreen.kt
@@ -401,9 +401,7 @@ fun DashboardScreen(
 }
 
 /* ---------- shared palette ---------- */
-private val Crimson = md_theme_light_primary
-private val OnCrimson = Color.White
-private val JetBlack = md_theme_light_onBackground
+/* Removed color aliases; use theme colors directly */
 
 /* ---------- reusable template ---------- */
 @Composable
@@ -418,7 +416,7 @@ private fun StaticInfoScreen(
             .fillMaxSize()
             .background(
                 Brush.verticalGradient(
-                    colors = listOf(Crimson, JetBlack),
+                    colors = listOf(md_theme_light_primary, md_theme_light_onBackground),
                     startY = 0f,
                     endY = Float.POSITIVE_INFINITY
                 )
@@ -430,7 +428,7 @@ private fun StaticInfoScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(24.dp),
-            colors = CardDefaults.cardColors(containerColor = OnCrimson),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
             elevation = CardDefaults.cardElevation(defaultElevation = 12.dp),
             shape = RoundedCornerShape(24.dp)
         ) {
@@ -454,7 +452,7 @@ private fun StaticInfoScreen(
                     modifier = Modifier
                         .height(4.dp)
                         .fillMaxWidth()
-                        .background(Crimson, RoundedCornerShape(topStart = 0.dp, topEnd = 0.dp))
+                        .background(md_theme_light_primary, RoundedCornerShape(topStart = 0.dp, topEnd = 0.dp))
                 )
 
                 Spacer(Modifier.height(24.dp))
@@ -462,7 +460,7 @@ private fun StaticInfoScreen(
                 Text(
                     text = title,
                     style = MaterialTheme.typography.headlineMedium.copy(
-                        color = Crimson,
+                        color = md_theme_light_primary,
                         fontWeight = FontWeight.Bold
                     ),
                     textAlign = TextAlign.Center
@@ -473,7 +471,7 @@ private fun StaticInfoScreen(
                 Text(
                     text = body,
                     style = MaterialTheme.typography.bodyLarge.copy(
-                        color = JetBlack,
+                        color = md_theme_light_onBackground,
                         lineHeight = 22.sp
                     ),
                     textAlign = TextAlign.Center

--- a/app/src/main/java/com/example/blooddonation/feature/events/BloodCampListScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/events/BloodCampListScreen.kt
@@ -158,13 +158,10 @@ fun BloodCampItem(
     isRegistered: Boolean,
     onRegisterClick: () -> Unit
 ) {
-    val redColor = MaterialTheme.colorScheme.primary
-    val blackColor = MaterialTheme.colorScheme.onBackground
-    val whiteColor = MaterialTheme.colorScheme.onPrimary
 
     Card(
         modifier = modifier,
-        colors = CardDefaults.cardColors(containerColor = whiteColor),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.onPrimary),
         elevation = CardDefaults.cardElevation()
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -180,22 +177,22 @@ fun BloodCampItem(
                 Spacer(modifier = Modifier.height(8.dp))
             }
 
-            Text(text = camp.name, style = MaterialTheme.typography.titleLarge, color = redColor)
-            Text(text = "Location: ${camp.location}", color = blackColor)
-            Text(text = "Date: ${camp.date}", color = blackColor)
-            Text(text = camp.description, color = blackColor)
+            Text(text = camp.name, style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.primary)
+            Text(text = "Location: ${camp.location}", color = MaterialTheme.colorScheme.onBackground)
+            Text(text = "Date: ${camp.date}", color = MaterialTheme.colorScheme.onBackground)
+            Text(text = camp.description, color = MaterialTheme.colorScheme.onBackground)
 
             Spacer(modifier = Modifier.height(8.dp))
             Button(
                 onClick = onRegisterClick,
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = if (isRegistered) Color.Gray else redColor
+                    containerColor = if (isRegistered) Color.Gray else MaterialTheme.colorScheme.primary
                 ),
                 enabled = !isRegistered
             ) {
                 Text(
                     text = if (isRegistered) "Registered" else "Register",
-                    color = whiteColor
+                    color = MaterialTheme.colorScheme.onPrimary
                 )
             }
         }

--- a/app/src/main/java/com/example/blooddonation/feature/profile/MyProfileScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/profile/MyProfileScreen.kt
@@ -84,9 +84,6 @@ fun MyProfileScreen(
                 ProfileViewModel(uid) as T
         })
 ) {
-    val Crimson = MaterialTheme.colorScheme.primary
-    val Snow = MaterialTheme.colorScheme.onPrimary
-    val Jet = MaterialTheme.colorScheme.onBackground
 
     val profile by viewModel.profile.collectAsState()
     val ctx = LocalContext.current
@@ -103,7 +100,7 @@ fun MyProfileScreen(
 
     if (profile == null) {
         Box(Modifier.fillMaxSize(), Alignment.Center) {
-            CircularProgressIndicator(color = Crimson)
+            CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
         }
         return
     }
@@ -130,9 +127,9 @@ fun MyProfileScreen(
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = Crimson,
-                    titleContentColor = Snow,
-                    navigationIconContentColor = Snow
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimary,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onPrimary
                 )
             )
         }
@@ -141,7 +138,7 @@ fun MyProfileScreen(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(Jet)
+                    .background(MaterialTheme.colorScheme.onBackground)
                     .padding(pad)
             ) {
                 Box(
@@ -166,7 +163,7 @@ fun MyProfileScreen(
                             .align(Alignment.BottomCenter)
                             .offset(y = 78.dp)
                             .clip(CircleShape)
-                            .border(4.dp, Snow, CircleShape)
+                            .border(4.dp, MaterialTheme.colorScheme.onPrimary, CircleShape)
                             .shadow(12.dp, CircleShape)
                     ) {
                         Image(
@@ -186,11 +183,11 @@ fun MyProfileScreen(
                         .padding(horizontal = 32.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    Text("Username:", color = Snow.copy(alpha = 0.7f))
+                    Text("Username:", color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.7f))
                     Text(
                         user.username,
                         style = MaterialTheme.typography.headlineMedium.copy(
-                            color = Snow,
+                            color = MaterialTheme.colorScheme.onPrimary,
                             fontWeight = FontWeight.Bold
                         ),
                         textAlign = TextAlign.Center
@@ -198,11 +195,11 @@ fun MyProfileScreen(
 
                     Spacer(Modifier.height(12.dp))
 
-                    Text("Blood Group:", color = Snow.copy(alpha = 0.7f))
+                    Text("Blood Group:", color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.7f))
                     Text(
                         user.bloodGroup,
                         style = MaterialTheme.typography.titleLarge.copy(
-                            color = Crimson,
+                            color = MaterialTheme.colorScheme.primary,
                             fontWeight = FontWeight.SemiBold
                         ),
                         textAlign = TextAlign.Center
@@ -211,7 +208,7 @@ fun MyProfileScreen(
                     Spacer(Modifier.height(24.dp))
 
                     Card(
-                        colors = CardDefaults.cardColors(containerColor = Snow.copy(alpha = 0.1f)),
+                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.1f)),
                         elevation = CardDefaults.cardElevation(0.dp),
                         modifier = Modifier.fillMaxWidth()
                     ) {
@@ -219,7 +216,7 @@ fun MyProfileScreen(
                             user.bio.ifBlank { "No bio added yet." },
                             modifier = Modifier.padding(20.dp),
                             textAlign = TextAlign.Center,
-                            style = MaterialTheme.typography.bodyLarge.copy(color = Snow)
+                            style = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onPrimary)
                         )
                     }
 
@@ -233,11 +230,11 @@ fun MyProfileScreen(
                             editMode = true
                         },
                         shape = RoundedCornerShape(32.dp),
-                        colors = ButtonDefaults.buttonColors(containerColor = Crimson),
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(54.dp)
-                    ) { Text("Edit Profile", color = Snow) }
+                    ) { Text("Edit Profile", color = MaterialTheme.colorScheme.onPrimary) }
                 }
             }
         }  else {
@@ -246,7 +243,7 @@ fun MyProfileScreen(
                 modifier = Modifier
                     .verticalScroll(rememberScrollState())
                     .fillMaxSize()
-                    .background(Jet)
+                    .background(MaterialTheme.colorScheme.onBackground)
                     .padding(pad)
                     .padding(24.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
@@ -270,7 +267,7 @@ fun MyProfileScreen(
                             .background(Color.Black.copy(alpha = 0.35f)),
                         contentAlignment = Alignment.Center
                     ) {
-                        Icon(Icons.Default.Edit, null, tint = Snow)
+                        Icon(Icons.Default.Edit, null, tint = MaterialTheme.colorScheme.onPrimary)
                     }
                 }
 
@@ -278,7 +275,7 @@ fun MyProfileScreen(
 
                 fun Modifier.field() = this
                     .fillMaxWidth()
-                    .background(Snow.copy(alpha = 0.05f), RoundedCornerShape(18.dp))
+                    .background(MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.05f), RoundedCornerShape(18.dp))
 
                 OutlinedTextField(
                     value = tmpName,
@@ -287,13 +284,13 @@ fun MyProfileScreen(
                     singleLine = true,
                     modifier = Modifier.field(),
                     colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor   = Crimson,
-                        unfocusedBorderColor = Snow.copy(alpha = 0.3f),
-                        focusedLabelColor    = Crimson,
-                        unfocusedLabelColor  = Snow.copy(alpha = 0.5f),
-                        cursorColor          = Crimson,
-                        focusedTextColor     = Snow,
-                        unfocusedTextColor   = Snow
+                        focusedBorderColor   = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.3f),
+                        focusedLabelColor    = MaterialTheme.colorScheme.primary,
+                        unfocusedLabelColor  = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.5f),
+                        cursorColor          = MaterialTheme.colorScheme.primary,
+                        focusedTextColor     = MaterialTheme.colorScheme.onPrimary,
+                        unfocusedTextColor   = MaterialTheme.colorScheme.onPrimary
                     )
                 )
 
@@ -308,13 +305,13 @@ fun MyProfileScreen(
                         .heightIn(min = 120.dp)
                         .field(),
                     colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor   = Crimson,
-                        unfocusedBorderColor = Snow.copy(alpha = 0.3f),
-                        focusedLabelColor    = Crimson,
-                        unfocusedLabelColor  = Snow.copy(alpha = 0.5f),
-                        cursorColor          = Crimson,
-                        focusedTextColor     = Snow,
-                        unfocusedTextColor   = Snow
+                        focusedBorderColor   = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.3f),
+                        focusedLabelColor    = MaterialTheme.colorScheme.primary,
+                        unfocusedLabelColor  = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.5f),
+                        cursorColor          = MaterialTheme.colorScheme.primary,
+                        focusedTextColor     = MaterialTheme.colorScheme.onPrimary,
+                        unfocusedTextColor   = MaterialTheme.colorScheme.onPrimary
                     )
                 )
 
@@ -327,13 +324,13 @@ fun MyProfileScreen(
                     singleLine = true,
                     modifier = Modifier.field(),
                     colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor   = Crimson,
-                        unfocusedBorderColor = Snow.copy(alpha = 0.3f),
-                        focusedLabelColor    = Crimson,
-                        unfocusedLabelColor  = Snow.copy(alpha = 0.5f),
-                        cursorColor          = Crimson,
-                        focusedTextColor     = Snow,
-                        unfocusedTextColor   = Snow
+                        focusedBorderColor   = MaterialTheme.colorScheme.primary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.3f),
+                        focusedLabelColor    = MaterialTheme.colorScheme.primary,
+                        unfocusedLabelColor  = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.5f),
+                        cursorColor          = MaterialTheme.colorScheme.primary,
+                        focusedTextColor     = MaterialTheme.colorScheme.onPrimary,
+                        unfocusedTextColor   = MaterialTheme.colorScheme.onPrimary
                     )
                 )
 
@@ -353,17 +350,17 @@ fun MyProfileScreen(
                             pickedImage = null
                             editMode = false
                         },
-                        colors = ButtonDefaults.buttonColors(containerColor = Crimson),
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
                         shape  = RoundedCornerShape(32.dp),
                         modifier = Modifier.weight(1f).height(52.dp)
-                    ) { Text("Save", color = Snow) }
+                    ) { Text("Save", color = MaterialTheme.colorScheme.onPrimary) }
 
                     OutlinedButton(
                         onClick = { editMode = false; pickedImage = null },
                         shape = RoundedCornerShape(32.dp),
-                        border = BorderStroke(2.dp, Crimson),
+                        border = BorderStroke(2.dp, MaterialTheme.colorScheme.primary),
                         modifier = Modifier.weight(1f).height(52.dp)
-                    ) { Text("Cancel", color = Crimson) }
+                    ) { Text("Cancel", color = MaterialTheme.colorScheme.primary) }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- drop custom color aliases in favor of theme colors
- update screens to reference the Material theme colors directly

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449dc036408325a2c186cbccfbd09d