### PR TITLE
Fix logout stack and signup link

### DIFF
--- a/app/src/main/java/com/example/blooddonation/feature/admin/AdminDashboardScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/admin/AdminDashboardScreen.kt
@@ -228,7 +228,8 @@ fun AdminDashboardScreen(
                     onClick = {
                         FirebaseAuth.getInstance().signOut()
                         navController.navigate("signin") {
-                            popUpTo("admin_dashboard") { inclusive = true }
+                            popUpTo("splash") { inclusive = true }
+                            launchSingleTop = true
                         }
                         showLogoutDialog = false
                     },

--- a/app/src/main/java/com/example/blooddonation/feature/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/dashboard/DashboardScreen.kt
@@ -149,7 +149,8 @@ fun DashboardScreen(
                         scope.launch { drawerState.close() }
                         FirebaseAuth.getInstance().signOut()
                         navController.navigate("signin") {
-                            popUpTo("dashboard") { inclusive = true }
+                            popUpTo("splash") { inclusive = true }
+                            launchSingleTop = true
                         }
                     }
                 )

--- a/app/src/main/java/com/example/blooddonation/feature/signin/SignInScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/signin/SignInScreen.kt
@@ -3,12 +3,14 @@ package com.example.blooddonation.feature.signin
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -111,6 +113,27 @@ fun SignInScreen(
                 } else {
                     Text("Sign In", color = MaterialTheme.colorScheme.onPrimary)
                 }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("Don't have an account? ")
+                Text(
+                    text = "Sign Up",
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .padding(start = 4.dp)
+                        .alignByBaseline()
+                        .clickable {
+                            navController.navigate("signup") {
+                                launchSingleTop = true
+                                popUpTo("splash") { inclusive = true }
+                            }
+                        }
+                )
             }
 
             errorMessage?.let {


### PR DESCRIPTION
## Summary
- make logout navigation clear the stack so back exits
- add a 'Sign Up' link on the sign-in screen

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ad451bbc8325b9d2c76a80af48e2