### PR TITLE
Fix ViewDonorsScreen UI

### DIFF
--- a/app/src/main/java/com/example/blooddonation/navigation/Navigation.kt
+++ b/app/src/main/java/com/example/blooddonation/navigation/Navigation.kt
@@ -207,6 +207,7 @@ fun AppNavigation(navController: NavHostController) {
                 onNavigateToChat = { chatId, currentId, requesterId ->
                     navController.navigate("chat/$chatId/$currentId/$requesterId")
                 },
+                onBack = { navController.popBackStack() },
                 viewModel = bloodRequestViewModel,
                 currentUserId = currentUserId
             )


### PR DESCRIPTION
## Summary
- refactor `ViewDonorsScreen` to use a scaffold with a top app bar
- remove heavy background image and use theme colors instead
- compute filtered lists with `remember`
- add back navigation from `ViewDonorsScreen`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bce6dae08325ad711792a61eb98a