### PR TITLE
Add global theme switch

### DIFF
--- a/app/src/main/java/com/example/blooddonation/feature/BloodBankApp.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/BloodBankApp.kt
@@ -3,31 +3,44 @@ package com.example.blooddonation.feature
 import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.navigation.compose.rememberNavController
 import com.example.blooddonation.navigation.AppNavigation
 import com.example.blooddonation.feature.theme.BloodBankTheme
+import com.example.blooddonation.feature.theme.LocalIsDarkTheme
+import com.example.blooddonation.feature.theme.LocalToggleTheme
 import com.google.firebase.auth.FirebaseUser
 
 @Composable
 fun BloodBankApp(currentUser: FirebaseUser?) {
-    BloodBankTheme {
-        val navController = rememberNavController()
+    var isDarkTheme by remember { mutableStateOf(true) }
+    CompositionLocalProvider(
+        LocalIsDarkTheme provides isDarkTheme,
+        LocalToggleTheme provides { isDarkTheme = !isDarkTheme }
+    ) {
+        BloodBankTheme(darkTheme = isDarkTheme) {
+            val navController = rememberNavController()
 
-        LaunchedEffect(Unit) {
-            if (currentUser != null) {
-                val name = currentUser.displayName ?: "Default Name"
-                val imageUri = currentUser.photoUrl?.toString() ?: "default_image_uri"
+            LaunchedEffect(Unit) {
+                if (currentUser != null) {
+                    val name = currentUser.displayName ?: "Default Name"
+                    val imageUri = currentUser.photoUrl?.toString() ?: "default_image_uri"
 
-                // Logging the values before navigation
-                Log.d("BloodBankApp", "Navigating to dashboard with name: $name, imageUri: $imageUri")
-                if (name.isNotEmpty() && imageUri.isNotEmpty()) {
-                    navController.navigate("dashboard/$name/$imageUri")
-                } else {
-                    Log.e("BloodBankApp", "Navigation arguments are invalid: name='$name', imageUri='$imageUri'")
+                    // Logging the values before navigation
+                    Log.d("BloodBankApp", "Navigating to dashboard with name: $name, imageUri: $imageUri")
+                    if (name.isNotEmpty() && imageUri.isNotEmpty()) {
+                        navController.navigate("dashboard/$name/$imageUri")
+                    } else {
+                        Log.e("BloodBankApp", "Navigation arguments are invalid: name='$name', imageUri='$imageUri'")
+                    }
                 }
             }
-        }
 
-        AppNavigation(navController)
+            AppNavigation(navController)
+        }
     }
 }

--- a/app/src/main/java/com/example/blooddonation/feature/admin/AdminDashboardScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/admin/AdminDashboardScreen.kt
@@ -62,6 +62,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.firebase.auth.FirebaseAuth
 import coil.compose.rememberAsyncImagePainter
 import com.example.blooddonation.domain.AdminBloodCamp
+import com.example.blooddonation.feature.theme.ThemeSwitch
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -129,6 +130,7 @@ fun AdminDashboardScreen(
                     }
                 },
                 actions = {
+                    ThemeSwitch()
                     IconButton(onClick = { showLogoutDialog = true }) {
                         Icon(
                             painter = painterResource(id = R.drawable.ic_logout),

--- a/app/src/main/java/com/example/blooddonation/feature/chat/ChatScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/chat/ChatScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import com.example.blooddonation.feature.theme.ThemeSwitch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -60,6 +61,9 @@ fun ChatScreen(
                     IconButton(onClick = onBack) {
                         Icon(Icons.Default.ArrowBack, contentDescription = "Back")
                     }
+                },
+                actions = {
+                    ThemeSwitch()
                 },
                 colors = androidx.compose.material3.TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/com/example/blooddonation/feature/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/dashboard/DashboardScreen.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.example.blooddonation.R
+import com.example.blooddonation.feature.theme.ThemeSwitch
 import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.launch
 import java.io.File
@@ -177,6 +178,9 @@ fun DashboardScreen(
                                 tint = colorScheme.onPrimary
                             )
                         }
+                    },
+                    actions = {
+                        ThemeSwitch()
                     },
                     colors = TopAppBarDefaults.topAppBarColors(containerColor = colorScheme.primary)
                 )

--- a/app/src/main/java/com/example/blooddonation/feature/profile/MyProfileScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/profile/MyProfileScreen.kt
@@ -68,6 +68,7 @@ import coil.compose.rememberAsyncImagePainter
 import java.io.File
 import androidx.lifecycle.ViewModelProvider
 import coil.request.ImageRequest
+import com.example.blooddonation.feature.theme.ThemeSwitch
 import com.example.blooddonation.R
 
 
@@ -125,6 +126,9 @@ fun MyProfileScreen(
                     IconButton(onClick = onBack) {
                         Icon(Icons.Default.ArrowBack, contentDescription = "Back")
                     }
+                },
+                actions = {
+                    ThemeSwitch()
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/com/example/blooddonation/feature/requestblood/BloodRequestScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/requestblood/BloodRequestScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.blooddonation.R
 import com.example.blooddonation.domain.BloodRequest
+import com.example.blooddonation.feature.theme.ThemeSwitch
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -80,6 +81,9 @@ fun BloodRequestScreen(
                     IconButton(onClick = onBack) {
                         Icon(Icons.Default.ArrowBack, contentDescription = "Back")
                     }
+                },
+                actions = {
+                    ThemeSwitch()
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/com/example/blooddonation/feature/theme/ThemeToggle.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/theme/ThemeToggle.kt
@@ -1,0 +1,15 @@
+package com.example.blooddonation.feature.theme
+
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+
+val LocalIsDarkTheme = compositionLocalOf { true }
+val LocalToggleTheme = compositionLocalOf<() -> Unit> { { } }
+
+@Composable
+fun ThemeSwitch() {
+    val isDark = LocalIsDarkTheme.current
+    val toggle = LocalToggleTheme.current
+    Switch(checked = isDark, onCheckedChange = { toggle() })
+}

--- a/app/src/main/java/com/example/blooddonation/feature/viewdonors/ViewDonorsScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/viewdonors/ViewDonorsScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.window.Dialog
 import com.example.blooddonation.domain.BloodRequest
 import com.example.blooddonation.feature.requestblood.BloodRequestViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.blooddonation.feature.theme.ThemeSwitch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -98,6 +99,9 @@ fun ViewDonorsScreen(
                     IconButton(onClick = onBack) {
                         Icon(Icons.Default.ArrowBack, contentDescription = "Back")
                     }
+                },
+                actions = {
+                    ThemeSwitch()
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primary,


### PR DESCRIPTION
## Summary
- add a CompositionLocal based theme toggle
- expose ThemeSwitch in all top app bars
- set dark theme as default

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844cce330688325ba89592b8e6574c2