### PR TITLE
Improve camp list screens

### DIFF
--- a/app/src/main/java/com/example/blooddonation/feature/admin/AdminDashboardScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/admin/AdminDashboardScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowBack
@@ -48,7 +47,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -68,16 +66,15 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import com.example.blooddonation.R
+import com.example.blooddonation.feature.events.CampCard
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -176,14 +173,33 @@ fun AdminDashboardScreen(
             // Camp List
             LazyColumn(state = listState) {
                 items(shownCamps, key = { it.id }) { camp ->
-                    CampItem(
-                        camp = camp,
-                        onEdit = {
-                            selectedCamp = it
-                            showDialog = true
-                        },
-                        onDelete = { viewModel.deleteCamp(it.id) }
-                    )
+                    CampCard(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(8.dp),
+                        name = camp.name,
+                        location = camp.location,
+                        date = camp.date,
+                        description = camp.description,
+                        imagePath = camp.imageUrl
+                    ) {
+                        Button(
+                            onClick = {
+                                selectedCamp = camp
+                                showDialog = true
+                            },
+                            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+                        ) {
+                            Text("Edit", color = MaterialTheme.colorScheme.onPrimary)
+                        }
+                        Spacer(Modifier.width(8.dp))
+                        Button(
+                            onClick = { viewModel.deleteCamp(camp.id) },
+                            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.onBackground)
+                        ) {
+                            Text("Delete", color = MaterialTheme.colorScheme.onPrimary)
+                        }
+                    }
                 }
 
                 if (shownCamps.isEmpty()) {
@@ -245,85 +261,6 @@ fun AdminDashboardScreen(
     }
 }
 
-
-@Composable
-fun CampItem(
-    camp: AdminBloodCamp,
-    onEdit: (AdminBloodCamp) -> Unit,
-    onDelete: (AdminBloodCamp) -> Unit
-) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.onPrimary),
-        elevation = CardDefaults.cardElevation()
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-        ) {
-            Row(
-                modifier = Modifier,
-                verticalAlignment = Alignment.Top
-            ) {
-                // Image on the left as a rounded image
-                if (camp.imageUrl.isNotEmpty()) {
-                    val imageFile = rememberSaveable { File(camp.imageUrl) }
-                    if (imageFile.exists()) {
-                        Image(
-                            painter = rememberAsyncImagePainter(imageFile),
-                            contentScale = ContentScale.Crop,
-                            contentDescription = null,
-                            modifier = Modifier
-                                .size(72.dp)
-                                .clip(CircleShape)
-                        )
-                    }
-                } else {
-                    // Placeholder (optional)
-                    Icon(
-                        imageVector = Icons.Default.AccountCircle,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier
-                            .size(72.dp)
-                            .clip(CircleShape)
-                    )
-                }
-                Spacer(modifier = Modifier.width(16.dp))
-                // Details and buttons
-                Column(
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text(
-                        text = camp.name,
-                        style = MaterialTheme.typography.titleLarge,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                    Text(text = "Location: ${camp.location}", color = MaterialTheme.colorScheme.onBackground)
-                    Text(text = "Date: ${camp.date}", color = MaterialTheme.colorScheme.onBackground)
-                    Text(text = camp.description, color = MaterialTheme.colorScheme.onBackground, maxLines = 2)
-                }
-            }
-            Spacer(modifier = Modifier.height(8.dp))
-            Row {
-                Button(
-                    onClick = { onEdit(camp) },
-                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
-                ) {
-                    Text("Edit", color = MaterialTheme.colorScheme.onPrimary)
-                }
-                Spacer(modifier = Modifier.width(8.dp))
-                Button(
-                    onClick = { onDelete(camp) },
-                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.onBackground)
-                ) {
-                    Text("Delete", color = MaterialTheme.colorScheme.onPrimary)
-                }
-            }
-        }
-    }
-}
 
 @Composable
 fun CampDialog(

--- a/app/src/main/java/com/example/blooddonation/feature/events/BloodCampListScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/events/BloodCampListScreen.kt
@@ -1,7 +1,6 @@
 package com.example.blooddonation.feature.events
 
 import BloodCampViewModel
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -16,17 +15,17 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -34,17 +33,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import coil.compose.rememberAsyncImagePainter
 import com.example.blooddonation.domain.BloodCamp
+import com.example.blooddonation.feature.events.CampCard
+import com.example.blooddonation.feature.theme.ThemeSwitch
 
 @Composable
-fun BloodCampListScreen(viewModel: BloodCampViewModel = viewModel()) {
+@OptIn(ExperimentalMaterial3Api::class)
+fun BloodCampListScreen(onBack: () -> Unit = {}, viewModel: BloodCampViewModel = viewModel()) {
     val camps by viewModel.camps.collectAsStateWithLifecycle()
     val registeredCampIds by viewModel.registeredCampIds.collectAsStateWithLifecycle()
 
@@ -59,145 +59,93 @@ fun BloodCampListScreen(viewModel: BloodCampViewModel = viewModel()) {
         else list.sortedByDescending { it.date }
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black)
-            .padding(16.dp)
-    ) {
-        // Search bar and sort button Row
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.primaryContainer,
+        topBar = {
+            TopAppBar(
+                title = { Text("Blood Camps") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = { ThemeSwitch() },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimary,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
         ) {
-            // Search text field
-            TextField(
-                value = searchQuery,
-                onValueChange = { searchQuery = it },
-                placeholder = {
-                    Text(
-                        "Search by location",
-                        color = Color.LightGray
-                    )
-                }, // Set placeholder text color here
-                modifier = Modifier.weight(1f),
-                colors = TextFieldDefaults.colors(
-                    focusedContainerColor = Color.DarkGray,
-                    unfocusedContainerColor = Color.DarkGray,
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    cursorColor = Color.White,
-                    focusedPlaceholderColor = Color.LightGray,
-                    unfocusedPlaceholderColor = Color.LightGray
-                ),
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    placeholder = { Text("Search by location") },
+                    modifier = Modifier.weight(1f),
+                    singleLine = true
+                )
 
-                singleLine = true,
-                trailingIcon = {
-                    if (searchQuery.isNotEmpty()) {
-                        IconButton(onClick = { searchQuery = "" }) {
-                            Icon(
-                                Icons.Default.Clear,
-                                contentDescription = "Clear search",
-                                tint = Color.White
+                Spacer(modifier = Modifier.width(8.dp))
+
+                IconButton(onClick = { isSortAscending = !isSortAscending }) {
+                    Icon(Icons.Default.ArrowDropDown, contentDescription = "Sort by date")
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            LazyColumn {
+                items(filteredCamps, key = { it.id }) { camp ->
+                    CampCard(
+                        modifier = Modifier.fillMaxWidth(),
+                        name = camp.name,
+                        location = camp.location,
+                        date = camp.date,
+                        description = camp.description,
+                        imagePath = camp.imageUrl
+                    ) {
+                        Button(
+                            onClick = { viewModel.registerForCamp(camp.id) },
+                            enabled = !registeredCampIds.contains(camp.id),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = if (registeredCampIds.contains(camp.id)) Color.Gray else MaterialTheme.colorScheme.primary
+                            )
+                        ) {
+                            Text(
+                                text = if (registeredCampIds.contains(camp.id)) "Registered" else "Register",
+                                color = MaterialTheme.colorScheme.onPrimary
                             )
                         }
                     }
+                    Spacer(modifier = Modifier.height(16.dp))
                 }
-            )
 
-
-            Spacer(modifier = Modifier.width(8.dp))
-
-            // Sort button
-            IconButton(
-                onClick = { isSortAscending = !isSortAscending },
-                modifier = Modifier.size(48.dp)
-            ) {
-                Icon(
-                    imageVector = if (isSortAscending) Icons.Default.ArrowDropDown else Icons.Default.ArrowDropDown,
-                    contentDescription = "Sort by date",
-                    tint = Color.White
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // LazyColumn of filtered camps
-        LazyColumn {
-            items(filteredCamps) { camp ->
-                BloodCampItem(
-                    modifier = Modifier.fillMaxWidth(),
-                    camp = camp,
-                    isRegistered = registeredCampIds.contains(camp.id),
-                    onRegisterClick = { viewModel.registerForCamp(camp.id) }
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-            }
-
-            if (filteredCamps.isEmpty()) {
-                item {
-                    Text(
-                        "No camps found for \"$searchQuery\"",
-                        modifier = Modifier.fillMaxWidth(),
-                        color = Color.LightGray,
-                        style = MaterialTheme.typography.bodyMedium,
-                        textAlign = TextAlign.Center
-                    )
+                if (filteredCamps.isEmpty()) {
+                    item {
+                        Text(
+                            "No camps found for \"$searchQuery\"",
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(32.dp),
+                            textAlign = TextAlign.Center,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    }
                 }
             }
         }
     }
 }
-
-
-@Composable
-fun BloodCampItem(
-    modifier: Modifier = Modifier,
-    camp: BloodCamp,
-    isRegistered: Boolean,
-    onRegisterClick: () -> Unit
-) {
-
-    Card(
-        modifier = modifier,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.onPrimary),
-        elevation = CardDefaults.cardElevation()
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            if (camp.imageUrl.isNotEmpty()) {
-                Image(
-                    painter = rememberAsyncImagePainter(model = camp.imageUrl),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(180.dp)
-                        .clip(MaterialTheme.shapes.medium)
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-            }
-
-            Text(text = camp.name, style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.primary)
-            Text(text = "Location: ${camp.location}", color = MaterialTheme.colorScheme.onBackground)
-            Text(text = "Date: ${camp.date}", color = MaterialTheme.colorScheme.onBackground)
-            Text(text = camp.description, color = MaterialTheme.colorScheme.onBackground)
-
-            Spacer(modifier = Modifier.height(8.dp))
-            Button(
-                onClick = onRegisterClick,
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = if (isRegistered) Color.Gray else MaterialTheme.colorScheme.primary
-                ),
-                enabled = !isRegistered
-            ) {
-                Text(
-                    text = if (isRegistered) "Registered" else "Register",
-                    color = MaterialTheme.colorScheme.onPrimary
-                )
-            }
-        }
-    }
-}
-
-
 

--- a/app/src/main/java/com/example/blooddonation/feature/events/CampCard.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/events/CampCard.kt
@@ -1,0 +1,58 @@
+package com.example.blooddonation.feature.events
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import java.io.File
+
+@Composable
+fun CampCard(
+    modifier: Modifier = Modifier,
+    name: String,
+    location: String,
+    date: String,
+    description: String,
+    imagePath: String = "",
+    actionContent: @Composable RowScope.() -> Unit = {}
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.onPrimary),
+        elevation = CardDefaults.cardElevation()
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            if (imagePath.isNotEmpty()) {
+                val model = if (File(imagePath).exists()) File(imagePath) else imagePath
+                Image(
+                    painter = rememberAsyncImagePainter(model = model),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(180.dp)
+                        .clip(MaterialTheme.shapes.medium),
+                    contentScale = ContentScale.Crop
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            Text(name, style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.primary)
+            Text("Location: $location", color = MaterialTheme.colorScheme.onBackground)
+            Text("Date: $date", color = MaterialTheme.colorScheme.onBackground)
+            Text(description, color = MaterialTheme.colorScheme.onBackground)
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                content = actionContent
+            )
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/blooddonation/navigation/Navigation.kt
+++ b/app/src/main/java/com/example/blooddonation/navigation/Navigation.kt
@@ -230,7 +230,7 @@ fun AppNavigation(navController: NavHostController) {
         }
 
         composable("blood_camp_list") {
-            BloodCampListScreen()
+            BloodCampListScreen(onBack = { navController.popBackStack() })
         }
 
         composable(


### PR DESCRIPTION
## Summary
- add `CampCard` reusable composable
- refactor `BloodCampListScreen` to use Material theme and `CampCard`
- refactor admin dashboard camp list to use `CampCard`
- wire back navigation for blood camp list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845438aa01c8325b65020badd8c392e