### PR TITLE
Fix navigation back stack

### DIFF
--- a/app/src/main/java/com/example/blooddonation/navigation/Navigation.kt
+++ b/app/src/main/java/com/example/blooddonation/navigation/Navigation.kt
@@ -69,7 +69,7 @@ fun AppNavigation(navController: NavHostController) {
                 onSignInClick = {
                     navController.navigate(Screen.SignIn.route) {
                         launchSingleTop = true
-                        popUpTo(Screen.Splash.route) { inclusive = true }
+                        popUpTo(Screen.SignUp.route) { inclusive = true }
                     }
                 }
             )
@@ -85,7 +85,7 @@ fun AppNavigation(navController: NavHostController) {
                 onNavigateToSignup = {
                     navController.navigate(Screen.SignUp.route) {
                         launchSingleTop = true
-                        popUpTo(Screen.Splash.route) { inclusive = true }
+                        popUpTo(Screen.SignIn.route) { inclusive = true }
                     }
                 },
                 onSignInSuccess = { uid, isAdmin ->


### PR DESCRIPTION
## Summary
- ensure back stack is cleared when switching between SignUp and SignIn

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455af642ac83258823d99b98fb20f7