### PR TITLE
Add timestamp and username to blood requests

### DIFF
--- a/app/src/main/java/com/example/blooddonation/domain/BloodRequest.kt
+++ b/app/src/main/java/com/example/blooddonation/domain/BloodRequest.kt
@@ -5,6 +5,8 @@ package com.example.blooddonation.domain
 data class BloodRequest(
     val id: String = "",
     val requesterId: String = "",
+    val requesterName: String = "",
+    val timestamp: Long = 0L,
     val bloodGroup: String = "",
     val location: String = "",
     val status: String = "pending",

--- a/app/src/main/java/com/example/blooddonation/feature/requestblood/BloodRequestScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/requestblood/BloodRequestScreen.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.blooddonation.domain.BloodRequest
 import com.example.blooddonation.feature.theme.ThemeSwitch
+import com.google.firebase.firestore.FirebaseFirestore
+import androidx.compose.runtime.LaunchedEffect
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -55,8 +57,19 @@ fun BloodRequestScreen(
     var selectedBloodGroup by remember { mutableStateOf("") }
     var location by remember { mutableStateOf("") }
     var isLoading by remember { mutableStateOf(false) }
+    var userName by remember { mutableStateOf("") }
     val context = LocalContext.current
     val requests by viewModel.requests.collectAsState()
+
+    // Load the current user's name
+    LaunchedEffect(currentUserId) {
+        FirebaseFirestore.getInstance().collection("users")
+            .document(currentUserId)
+            .get()
+            .addOnSuccessListener { doc ->
+                userName = doc.getString("username") ?: ""
+            }
+    }
 
     // Get the accepted request (if any) for this user
     val acceptedRequest = requests.find {
@@ -155,6 +168,8 @@ fun BloodRequestScreen(
 
                             val newRequest = BloodRequest(
                                 requesterId = currentUserId,
+                                requesterName = userName,
+                                timestamp = System.currentTimeMillis(),
                                 bloodGroup = selectedBloodGroup,
                                 location = location,
                                 status = "pending"

--- a/app/src/main/java/com/example/blooddonation/feature/viewdonors/ViewDonorsScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/viewdonors/ViewDonorsScreen.kt
@@ -71,9 +71,12 @@ fun ViewDonorsScreen(
     val tabTitles = listOf("Pending", "Accepted", "Rejected")
 
     // --- Tab filtering logic ---
-    val pendingRequests = requests.filter { it.status == "pending" }
-    val acceptedRequests = requests.filter { it.status == "accepted" }
-    val rejectedRequests = requests.filter { it.status == "rejected" }
+    val pendingRequests =
+        requests.filter { it.status == "pending" }.sortedByDescending { it.timestamp }
+    val acceptedRequests =
+        requests.filter { it.status == "accepted" }.sortedByDescending { it.timestamp }
+    val rejectedRequests =
+        requests.filter { it.status == "rejected" }.sortedByDescending { it.timestamp }
 
     // Show medical dialog if needed
     showMedicalFormForRequest?.let { request ->
@@ -196,6 +199,7 @@ private fun AcceptedTab(
                     Column(Modifier.padding(16.dp)) {
                         Text("Blood Group: ${request.bloodGroup}", fontWeight = FontWeight.Bold)
                         Text("Location: ${request.location}")
+                        Text("Requester: ${request.requesterName}")
                         if (request.requesterId == currentUserId) {
                             Spacer(Modifier.height(8.dp))
                             Text(
@@ -251,6 +255,7 @@ private fun RejectedTab(requests: List<BloodRequest>, currentUserId: String) {
                     Column(Modifier.padding(16.dp)) {
                         Text("Blood Group: ${request.bloodGroup}", fontWeight = FontWeight.Bold)
                         Text("Location: ${request.location}")
+                        Text("Requester: ${request.requesterName}")
                         if (request.requesterId == currentUserId) {
                             Spacer(Modifier.height(8.dp))
                             Text(
@@ -294,6 +299,7 @@ fun RequestCard(
                 style = MaterialTheme.typography.titleMedium
             )
             Text(text = "Location: ${bloodRequest.location}")
+            Text(text = "Requester: ${bloodRequest.requesterName}")
 
             if (isRaisedByMe) {
                 Spacer(Modifier.height(8.dp))


### PR DESCRIPTION
## Summary
- store requester name and timestamp in `BloodRequest`
- fetch the user name when creating a new request
- include timestamp ordering in request lists
- display requester name in request cards

## Testing
- `./gradlew test --quiet` *(fails: download Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_6845682e183c832581261bd589fa654a