### PR TITLE
Fix chat visibility for accepted requests

### DIFF
--- a/app/src/main/java/com/example/blooddonation/feature/viewrequest/ViewRequestScreen.kt
+++ b/app/src/main/java/com/example/blooddonation/feature/viewrequest/ViewRequestScreen.kt
@@ -212,21 +212,41 @@ private fun AcceptedTab(
                                     )
                                     .padding(horizontal = 10.dp, vertical = 4.dp)
                             )
-                        }
-                        if (!request.chatId.isNullOrEmpty() && request.requesterId != currentUserId) {
+                        } else if (request.acceptedBy == currentUserId) {
                             Spacer(Modifier.height(8.dp))
-                            Button(
-                                onClick = {
-                                    onNavigateToChat(
-                                        request.chatId,
-                                        currentUserId,
-                                        request.requesterId
+                            Text(
+                                text = "Accepted by me",
+                                color = MaterialTheme.colorScheme.tertiaryContainer,
+                                fontWeight = FontWeight.Bold,
+                                modifier = Modifier
+                                    .background(
+                                        color = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.08f),
+                                        shape = RoundedCornerShape(8.dp)
                                     )
-                                },
-                                modifier = Modifier.fillMaxWidth(),
-                                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer)
-                            ) {
-                                Text("Go to Chat", color = MaterialTheme.colorScheme.onTertiaryContainer)
+                                    .padding(horizontal = 10.dp, vertical = 4.dp)
+                            )
+                        }
+                        if (!request.chatId.isNullOrEmpty()) {
+                            val otherUserId = if (request.requesterId == currentUserId) {
+                                request.acceptedBy
+                            } else {
+                                request.requesterId
+                            }
+                            if (!otherUserId.isNullOrEmpty()) {
+                                Spacer(Modifier.height(8.dp))
+                                Button(
+                                    onClick = {
+                                        onNavigateToChat(
+                                            request.chatId,
+                                            currentUserId,
+                                            otherUserId
+                                        )
+                                    },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer)
+                                ) {
+                                    Text("Go to Chat", color = MaterialTheme.colorScheme.onTertiaryContainer)
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- show chat button even when current user is requester
- determine chat partner properly
- display label when request was accepted by current user

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456f5690a4832585170493da86e46e